### PR TITLE
enable raw mode while capturing input

### DIFF
--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -1,6 +1,9 @@
 use crate::theme::{SimpleTheme, TermThemeRenderer, Theme};
 use console::Term;
-use crossterm::event::{read, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::{
+    event::{read, Event, KeyCode, KeyEvent, KeyModifiers},
+    terminal,
+};
 
 use fuzzy_matcher::FuzzyMatcher;
 use std::{io, ops::Rem};
@@ -213,6 +216,8 @@ impl FuzzySelect<'_> {
                 term.flush()?;
             }
 
+            terminal::enable_raw_mode()?;
+
             if let Event::Key(KeyEvent { code, modifiers }) = read().unwrap() {
                 match code {
                     KeyCode::Esc if allow_quit => {
@@ -278,6 +283,8 @@ impl FuzzySelect<'_> {
                             .iter()
                             .position(|item| item.eq(sel_string))
                             .unwrap();
+
+                        terminal::disable_raw_mode()?;
 
                         term.show_cursor()?;
 

--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -225,6 +225,7 @@ impl FuzzySelect<'_> {
                             render.clear()?;
                             term.flush()?;
                         }
+                        terminal::disable_raw_mode()?;
                         term.show_cursor()?;
                         return Ok(None);
                     }
@@ -307,6 +308,7 @@ impl FuzzySelect<'_> {
                 }
             }
 
+            terminal::disable_raw_mode()?;
             render.clear_preserve_prompt(&size_vec)?;
         }
     }

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -4,7 +4,10 @@ use crate::paging::Paging;
 use crate::theme::{SimpleTheme, TermThemeRenderer, Theme};
 
 use console::Term;
-use crossterm::event::{read, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::{
+    event::{read, Event, KeyCode, KeyEvent, KeyModifiers},
+    terminal,
+};
 
 /// Renders a select prompt.
 ///
@@ -283,6 +286,8 @@ impl Select<'_> {
 
             term.flush()?;
 
+            terminal::enable_raw_mode()?;
+
             if let Event::Key(KeyEvent { code, modifiers }) = read().unwrap() {
                 match code {
                     KeyCode::Down | KeyCode::Tab | KeyCode::Char('j') => {
@@ -345,6 +350,8 @@ impl Select<'_> {
                     _ => {}
                 }
             }
+
+            terminal::disable_raw_mode()?;
 
             paging.update(sel)?;
 

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -305,6 +305,7 @@ impl Select<'_> {
                                 term.clear_last_lines(paging.capacity)?;
                             }
 
+                            terminal::disable_raw_mode()?;
                             term.show_cursor()?;
                             term.flush()?;
 
@@ -342,6 +343,7 @@ impl Select<'_> {
                             }
                         }
 
+                        terminal::disable_raw_mode()?;
                         term.show_cursor()?;
                         term.flush()?;
 


### PR DESCRIPTION
Fix selection for unix

(there is still a bug present: `Enter`  doesn't register `Shift/Control` modifiers, only `Alt`