### PR TITLE
Revert "use fallback for active_item_prefix"

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -333,16 +333,7 @@ impl Default for ColorfulTheme {
             values_style: Style::new().for_stderr().green(),
             active_item_style: Style::new().for_stderr().cyan(),
             inactive_item_style: Style::new().for_stderr(),
-            active_item_prefix: style(
-                (if Term::stderr().features().wants_emoji() {
-                    "❯"
-                } else {
-                    ">"
-                })
-                .to_string(),
-            )
-            .for_stderr()
-            .green(),
+            active_item_prefix: style("❯".to_string()).for_stderr().green(),
             inactive_item_prefix: style(" ".to_string()).for_stderr(),
             checked_item_prefix: style("✔".to_string()).for_stderr().green(),
             unchecked_item_prefix: style("✔".to_string()).for_stderr().black(),


### PR DESCRIPTION
Reverts Araxeus/dialoguer#9

`Term::stderr().features().wants_emoji()` is broken and use fallback even on terminal that support emoji's (for example gnome-terminal)

